### PR TITLE
Update README signup link and bump Travis Ruby to 2.7.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.7.8
 before_install: gem install bundler -v 1.14.6

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 
 
 ### Getting Paubox API Credentials
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
 Once you have an account, follow the instructions on the Rest API dashboard to verify domain ownership and generate API credentials.
 


### PR DESCRIPTION
## Summary
- **README:** Repoint the "sign up here" link from the dead `https://www.paubox.com/join/see-pricing?unit=messages` URL to the current canonical Email API pricing page (`https://www.paubox.com/pricing/paubox-email-api`). No other `paubox.com` references in the repo were touched — the gemspec homepage and the `@paubox.com` email addresses in fixtures are unaffected.
- **CI:** Bump the Travis Ruby version from 2.3.1 to 2.7.8. Ruby 2.3.1 is long past end-of-life; align CI with a still-supported 2.7.x patch.

## Test plan
- [ ] Open the new README URL in a browser and confirm it lands on the Email API pricing page (200, no redirect chain).
- [ ] Confirm Travis picks up `.travis.yml` and the build runs against Ruby 2.7.8 successfully (`bundle install` + `rspec` should both pass on 2.7.8).
- [ ] Spot-check the README still renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)