### PR TITLE
Add Paubox Forms API support (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ paubox-rails
 ├── Email path
 │   ActionMailer → Mail::Paubox (from paubox gem) → RestClient → api.paubox.net
 └── Forms path
-    PauboxRails::Forms::Client → Net::HTTP → next.paubox.com
+    PauboxRails::Forms::Client → Net::HTTP → apx.paubox.com/forms
 ```
 
 - Email credentials (`api_key`, `api_user`) are configured via `Paubox.configure`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md — paubox-rails codebase guide
+
+## What this gem does
+
+`paubox-rails` is a thin Rails adapter gem with two responsibilities:
+
+1. **Email delivery** — Registers `:paubox` as an ActionMailer delivery method, delegating all sending to the [`paubox`](https://github.com/paubox/paubox_ruby) gem (`Mail::Paubox`).
+2. **Forms API client** — Provides `PauboxRails::Forms::Client` for interacting with the Paubox Forms public API (no auth required).
+
+## Key files
+
+```
+lib/
+  paubox_rails.rb               # Entry point: requires all components, registers delivery method
+  paubox_rails/
+    version.rb                  # VERSION constant
+    railtie.rb                  # Rails hook — registers delivery method before ActionMailer boots
+    forms.rb                    # PauboxRails::Forms module: BASE_URL, error classes, .client factory
+    forms/
+      client.rb                 # Forms HTTP client (Net::HTTP, no extra deps)
+spec/
+  paubox_rails_spec.rb          # Integration tests for ActionMailer delivery
+  paubox_rails/
+    forms/
+      client_spec.rb            # Unit tests for Forms::Client (Net::HTTP stubs)
+  fixtures/
+    models/test_mailer.rb       # Minimal ActionMailer subclass used in tests
+    views/test_mailer/          # ERB template for the test mailer
+```
+
+## Architecture
+
+```
+paubox-rails
+├── Email path
+│   ActionMailer → Mail::Paubox (from paubox gem) → RestClient → api.paubox.net
+└── Forms path
+    PauboxRails::Forms::Client → Net::HTTP → next.paubox.com
+```
+
+- Email credentials (`api_key`, `api_user`) are configured via `Paubox.configure`.
+- Forms endpoints are **public** — no credentials needed.
+
+## Running tests
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+## How to add a new Forms endpoint
+
+1. Add a method to `lib/paubox_rails/forms/client.rb` following the `get_form` / `submit_form` pattern.
+2. Use `build_http(uri)` to get an SSL-ready `Net::HTTP` instance.
+3. Call `handle_response(response)` for consistent error handling.
+4. Add corresponding tests in `spec/paubox_rails/forms/client_spec.rb`, stubbing `Net::HTTP.new` via `instance_double`.
+5. Document the new method in `api.md` and `README.md`.
+
+## How to add a new email feature
+
+Email functionality lives in the `paubox` gem (not here). This gem only bridges ActionMailer to `Mail::Paubox`. To add email features, update the `paubox` gem and bump its version constraint in `paubox_rails.gemspec`.
+
+## Version
+
+Current: `0.2.0` (in `lib/paubox_rails/version.rb`)
+
+- `0.1.x` — Initial releases, email delivery only
+- `0.2.0` — Added Paubox Forms API support

--- a/README.md
+++ b/README.md
@@ -75,6 +75,64 @@ class UserMailer < ApplicationMailer
 end
 ```
 
+## Paubox Forms
+
+The gem includes a client for the [Paubox Forms API](https://docs.paubox.com/forms). These endpoints are **public** — no API key or authentication is required.
+
+### Get form metadata
+
+Retrieves a form's full definition (HTML, JSON schema, CSS, metadata).
+
+```ruby
+client = PauboxRails::Forms::Client.new
+# or use the convenience factory:
+client = PauboxRails::Forms.client
+
+form = client.get_form('550e8400-e29b-41d4-a716-446655440000')
+puts form['title']            # => "Patient Intake Form"
+puts form['active']           # => true
+puts form['submission_count'] # => 42
+```
+
+Raises `PauboxRails::Forms::NotFoundError` if the form UUID does not exist.
+
+### Submit a form response
+
+Submits a respondent's answers for a form. On success, Paubox stores the submission, increments the submission count, and emails recipients (if configured).
+
+```ruby
+client.submit_form(
+  '550e8400-e29b-41d4-a716-446655440000',
+  form_data: {
+    first_name: 'Jane',
+    last_name:  'Smith',
+    email:      'jane@example.com'
+  }
+)
+# => true
+```
+
+#### With file attachments
+
+Attachments must be base64-encoded. Maximum request size is 250 MB.
+
+```ruby
+require 'base64'
+
+client.submit_form(
+  '550e8400-e29b-41d4-a716-446655440000',
+  form_data: { first_name: 'Jane' },
+  attachments: [
+    {
+      name:    'consent.pdf',
+      content: Base64.strict_encode64(File.read('consent.pdf'))
+    }
+  ]
+)
+```
+
+Raises `PauboxRails::Forms::BadRequestError` on a 400 response, or `PauboxRails::Forms::NotFoundError` if the form is not found.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/paubox/paubox-rails.

--- a/api.md
+++ b/api.md
@@ -9,7 +9,7 @@ This document covers the API endpoints exposed by `paubox-rails`. The gem wraps 
 
 ## Forms API
 
-**Base URL:** `https://next.paubox.com`
+**Base URL:** `https://apx.paubox.com/forms`
 
 No authentication is required for any Forms endpoint. These endpoints are called on behalf of form respondents, not server-side API consumers.
 

--- a/api.md
+++ b/api.md
@@ -1,0 +1,154 @@
+# Paubox API Reference
+
+This document covers the API endpoints exposed by `paubox-rails`. The gem wraps two separate Paubox services:
+
+- **Email API** — authenticated, delegates to the [`paubox`](https://github.com/paubox/paubox_ruby) gem via ActionMailer
+- **Forms API** — public (no authentication), implemented directly in this gem
+
+---
+
+## Forms API
+
+**Base URL:** `https://next.paubox.com`
+
+No authentication is required for any Forms endpoint. These endpoints are called on behalf of form respondents, not server-side API consumers.
+
+---
+
+### GET `/public/form_data/{form_id}` — Get form metadata
+
+Returns the full form definition for embedding and rendering.
+
+**Path parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `form_id` | UUID string | Yes | UUID of the form to retrieve |
+
+**Response — 200 OK**
+
+```json
+{
+  "id":                          "550e8400-e29b-41d4-a716-446655440000",
+  "title":                       "Patient Intake Form",
+  "description":                 "Please complete before your appointment.",
+  "form_json":                   {},
+  "form_html":                   "<form>...</form>",
+  "form_css":                    "form { font-family: sans-serif; }",
+  "vanity_url":                  null,
+  "version":                     1,
+  "active":                      true,
+  "customer_id":                 123,
+  "signable":                    false,
+  "signature_confirmation_label": null,
+  "submission_count":            42,
+  "type":                        null,
+  "deleted":                     false,
+  "archived":                    false,
+  "created_at":                  "2024-01-15T10:30:00Z",
+  "updated_at":                  "2024-06-01T08:00:00Z"
+}
+```
+
+**Error responses**
+
+| Status | Meaning |
+|--------|---------|
+| 404    | Form not found |
+
+**Ruby usage**
+
+```ruby
+client = PauboxRails::Forms.client
+form = client.get_form('550e8400-e29b-41d4-a716-446655440000')
+```
+
+---
+
+### POST `/api/forms/{form_id}/submissions` — Submit a form response
+
+Stores a respondent's answers, increments the submission count, and emails recipients (if configured). Returns 201 with no body on success.
+
+Maximum request size: **250 MB** (to support file attachments).
+
+**Path parameters**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `form_id` | UUID string | Yes | UUID of the form being submitted |
+
+**Request body** (`application/json`)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `form_data` | object | Yes | Key-value pairs matching the form's field schema |
+| `attachments` | array | No | Optional file attachments (see below) |
+
+**Attachment object**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Filename (e.g. `"consent.pdf"`) |
+| `content` | string | Yes | Base64-encoded file content |
+
+**Example — text fields only**
+
+```json
+{
+  "form_data": {
+    "first_name": "Jane",
+    "last_name":  "Smith",
+    "email":      "jane@example.com"
+  }
+}
+```
+
+**Example — with file attachment**
+
+```json
+{
+  "form_data": {
+    "first_name": "Jane"
+  },
+  "attachments": [
+    {
+      "name":    "consent.pdf",
+      "content": "JVBERi0xLjQ..."
+    }
+  ]
+}
+```
+
+**Response — 201 Created** (no body)
+
+**Error responses**
+
+| Status | Meaning |
+|--------|---------|
+| 400    | Missing required `form_data` field |
+| 404    | Form not found |
+
+**Ruby usage**
+
+```ruby
+client = PauboxRails::Forms.client
+
+# Simple submission
+client.submit_form(form_id, form_data: { first_name: 'Jane', email: 'jane@example.com' })
+
+# With attachment
+require 'base64'
+client.submit_form(
+  form_id,
+  form_data:   { first_name: 'Jane' },
+  attachments: [{ name: 'consent.pdf', content: Base64.strict_encode64(File.read('consent.pdf')) }]
+)
+```
+
+---
+
+## Email API
+
+Email delivery is handled transparently by ActionMailer using the `:paubox` delivery method. There is no direct HTTP interaction in this gem — all email API calls are delegated to the [`paubox`](https://github.com/paubox/paubox_ruby) gem.
+
+See the [Paubox Ruby gem documentation](https://github.com/paubox/paubox_ruby) for the full Email API reference, including message status tracking and templated messages.

--- a/lib/paubox_rails.rb
+++ b/lib/paubox_rails.rb
@@ -1,6 +1,7 @@
 require "paubox_rails/version"
 require 'action_mailer'
 require 'paubox'
+require 'paubox_rails/forms'
 
 module PauboxRails
   extend self

--- a/lib/paubox_rails/forms.rb
+++ b/lib/paubox_rails/forms.rb
@@ -2,7 +2,7 @@ require 'paubox_rails/forms/client'
 
 module PauboxRails
   module Forms
-    BASE_URL = 'https://next.paubox.com'.freeze
+    BASE_URL = 'https://apx.paubox.com/forms'.freeze
 
     class Error < StandardError; end
     class NotFoundError < Error; end

--- a/lib/paubox_rails/forms.rb
+++ b/lib/paubox_rails/forms.rb
@@ -1,0 +1,15 @@
+require 'paubox_rails/forms/client'
+
+module PauboxRails
+  module Forms
+    BASE_URL = 'https://next.paubox.com'.freeze
+
+    class Error < StandardError; end
+    class NotFoundError < Error; end
+    class BadRequestError < Error; end
+
+    def self.client
+      Client.new
+    end
+  end
+end

--- a/lib/paubox_rails/forms/client.rb
+++ b/lib/paubox_rails/forms/client.rb
@@ -1,0 +1,53 @@
+require 'net/http'
+require 'json'
+require 'uri'
+
+module PauboxRails
+  module Forms
+    class Client
+      def get_form(form_id)
+        uri = URI.parse("#{BASE_URL}/public/form_data/#{form_id}")
+        http = build_http(uri)
+        response = http.get(uri.path)
+        handle_response(response)
+      end
+
+      def submit_form(form_id, form_data:, attachments: nil)
+        uri = URI.parse("#{BASE_URL}/api/forms/#{form_id}/submissions")
+        http = build_http(uri)
+
+        payload = { form_data: form_data }
+        payload[:attachments] = attachments if attachments
+
+        request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+        request.body = payload.to_json
+
+        response = http.request(request)
+        handle_response(response)
+      end
+
+      private
+
+      def build_http(uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == 'https'
+        http
+      end
+
+      def handle_response(response)
+        case response.code.to_i
+        when 200
+          JSON.parse(response.body)
+        when 201
+          true
+        when 400
+          raise BadRequestError, "Bad request: #{response.body}"
+        when 404
+          raise NotFoundError, 'Form not found'
+        else
+          raise Error, "Unexpected response #{response.code}: #{response.body}"
+        end
+      end
+    end
+  end
+end

--- a/lib/paubox_rails/version.rb
+++ b/lib/paubox_rails/version.rb
@@ -1,3 +1,3 @@
 module PauboxRails
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/spec/paubox_rails/forms/client_spec.rb
+++ b/spec/paubox_rails/forms/client_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+RSpec.describe PauboxRails::Forms::Client do
+  let(:client) { described_class.new }
+  let(:form_id) { '550e8400-e29b-41d4-a716-446655440000' }
+  let(:http) { instance_double(Net::HTTP) }
+
+  before do
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+  end
+
+  describe '#get_form' do
+    let(:form_body) do
+      {
+        'id' => form_id,
+        'title' => 'Patient Intake Form',
+        'description' => 'Please complete before your appointment.',
+        'form_json' => {},
+        'form_html' => '<form>...</form>',
+        'form_css' => 'form { font-family: sans-serif; }',
+        'active' => true,
+        'customer_id' => 123,
+        'signable' => false,
+        'submission_count' => 42,
+        'created_at' => '2024-01-15T10:30:00Z',
+        'updated_at' => '2024-06-01T08:00:00Z'
+      }.to_json
+    end
+
+    it 'returns parsed form hash on 200' do
+      response = instance_double(Net::HTTPResponse, code: '200', body: form_body)
+      allow(http).to receive(:get).and_return(response)
+
+      result = client.get_form(form_id)
+      expect(result['title']).to eq('Patient Intake Form')
+      expect(result['submission_count']).to eq(42)
+    end
+
+    it 'raises NotFoundError on 404' do
+      response = instance_double(Net::HTTPResponse, code: '404', body: '')
+      allow(http).to receive(:get).and_return(response)
+
+      expect { client.get_form(form_id) }
+        .to raise_error(PauboxRails::Forms::NotFoundError, 'Form not found')
+    end
+  end
+
+  describe '#submit_form' do
+    it 'returns true on 201' do
+      response = instance_double(Net::HTTPResponse, code: '201', body: '')
+      allow(http).to receive(:request).and_return(response)
+
+      result = client.submit_form(form_id, form_data: { first_name: 'Jane', email: 'jane@example.com' })
+      expect(result).to be true
+    end
+
+    it 'raises BadRequestError on 400' do
+      response = instance_double(Net::HTTPResponse, code: '400', body: '{"error":"Missing form_data"}')
+      allow(http).to receive(:request).and_return(response)
+
+      expect { client.submit_form(form_id, form_data: {}) }
+        .to raise_error(PauboxRails::Forms::BadRequestError)
+    end
+
+    it 'raises NotFoundError on 404' do
+      response = instance_double(Net::HTTPResponse, code: '404', body: '')
+      allow(http).to receive(:request).and_return(response)
+
+      expect { client.submit_form(form_id, form_data: { name: 'Jane' }) }
+        .to raise_error(PauboxRails::Forms::NotFoundError, 'Form not found')
+    end
+
+    it 'includes attachments in the payload when provided' do
+      response = instance_double(Net::HTTPResponse, code: '201', body: '')
+      allow(http).to receive(:request) do |req|
+        payload = JSON.parse(req.body)
+        expect(payload['attachments']).to eq([{ 'name' => 'consent.pdf', 'content' => 'JVBERi0xLjQ=' }])
+        response
+      end
+
+      client.submit_form(
+        form_id,
+        form_data: { name: 'Jane' },
+        attachments: [{ name: 'consent.pdf', content: 'JVBERi0xLjQ=' }]
+      )
+    end
+
+    it 'omits attachments key when not provided' do
+      response = instance_double(Net::HTTPResponse, code: '201', body: '')
+      allow(http).to receive(:request) do |req|
+        payload = JSON.parse(req.body)
+        expect(payload).not_to have_key('attachments')
+        response
+      end
+
+      client.submit_form(form_id, form_data: { name: 'Jane' })
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `PauboxRails::Forms::Client` with two public (no-auth) endpoints: `get_form` and `submit_form`
- Sets Forms API base URL to `https://apx.paubox.com/forms`
- Adds `api.md` (full API reference), `CLAUDE.md` (codebase guide), and a Forms section in `README.md`
- Bumps version `0.1.6` → `0.2.0`

## Endpoints implemented

| Method | Path | Ruby method |
|--------|------|-------------|
| `GET` | `/public/form_data/{form_id}` | `client.get_form(form_id)` |
| `POST` | `/api/forms/{form_id}/submissions` | `client.submit_form(form_id, form_data:, attachments: nil)` |

Both endpoints are public — no API key required. The client uses Ruby stdlib `Net::HTTP` (no new gem dependencies).

## Test plan

- [ ] `bundle exec rspec` — all 9 examples pass (7 new Forms specs + 2 existing)
- [ ] `PauboxRails::Forms.client.get_form(<uuid>)` returns form hash against a real form
- [ ] `PauboxRails::Forms::BASE_URL` equals `'https://apx.paubox.com/forms'`

https://claude.ai/code/session_0184BBnv14crSqEEH35d79Jt